### PR TITLE
common: Fix FTBFS with spdlog >= 1.1.0 (Closes: #774)

### DIFF
--- a/src/common/slogger.cc
+++ b/src/common/slogger.cc
@@ -86,7 +86,7 @@ void lzfs::drop_all_logs() {
 bool lzfs::add_log_syslog() {
 #ifndef _WIN32
 	try {
-		spdlog::syslog_logger("syslog");
+		spdlog::syslog_logger_mt("syslog");
 		return true;
 	} catch (const spdlog::spdlog_ex &e) {
 		lzfs_pretty_syslog(LOG_ERR, "Adding syslog log failed: %s", e.what());

--- a/src/common/slogger.h
+++ b/src/common/slogger.h
@@ -27,6 +27,9 @@
 #endif
 #include "common/small_vector.h"
 #include "spdlog/spdlog.h"
+#include "spdlog/sinks/rotating_file_sink.h"
+#include "spdlog/sinks/syslog_sink.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
 
 typedef std::shared_ptr<spdlog::logger> LoggerPtr;
 


### PR DESCRIPTION
~~~~
 /build/lizardfs-3.13.0~rc1+dfsg/src/common/slogger.cc: In function 'bool lzfs::add_log_file(const char*, lzfs::log_level::LogLevel, int, int)':
 /build/lizardfs-3.13.0~rc1+dfsg/src/common/slogger.cc:67:30: error: 'rotating_logger_mt' is not a member of 'spdlog'
    LoggerPtr logger = spdlog::rotating_logger_mt(path, path, max_file_size, max_file_count);
                               ^~~~~~~~~~~~~~~~~~
 /build/lizardfs-3.13.0~rc1+dfsg/src/common/slogger.cc: In function 'bool lzfs::add_log_syslog()':
 /build/lizardfs-3.13.0~rc1+dfsg/src/common/slogger.cc:89:11: error: 'syslog_logger' is not a member of 'spdlog'
    spdlog::syslog_logger("syslog");
            ^~~~~~~~~~~~~
 /build/lizardfs-3.13.0~rc1+dfsg/src/common/slogger.cc:89:11: note: suggested alternative: 'register_logger'
    spdlog::syslog_logger("syslog");
            ^~~~~~~~~~~~~
            register_logger
 /build/lizardfs-3.13.0~rc1+dfsg/src/common/slogger.cc: In function 'bool lzfs::add_log_stderr(lzfs::log_level::LogLevel)':
 /build/lizardfs-3.13.0~rc1+dfsg/src/common/slogger.cc:100:30: error: 'stderr_color_mt' is not a member of 'spdlog'
    LoggerPtr logger = spdlog::stderr_color_mt("stderr");
                               ^~~~~~~~~~~~~~~
~~~~

Signed-off-by: Dmitry Smirnov <onlyjob@member.fsf.org>