### PR TITLE
Update matocl.h

### DIFF
--- a/src/protocol/matocl.h
+++ b/src/protocol/matocl.h
@@ -188,8 +188,8 @@ LIZARDFS_DEFINE_PACKET_SERIALIZATION(
 
 LIZARDFS_DEFINE_SERIALIZABLE_CLASS(FuseGetGoalStats,
 		std::string, goalName,
-		uint32_t, directories,
-		uint32_t, files);
+		uint32_t, files,
+		uint32_t, directories);
 
 LIZARDFS_DEFINE_PACKET_SERIALIZATION(
 		matocl, fuseGetGoal, LIZ_MATOCL_FUSE_GETGOAL, kResponsePacketVersion,


### PR DESCRIPTION
fix the serialization of FuseGetGoalStats to match what is written in matoclserv.cc.  The number of files is first, then directories.