### PR TITLE
Include errno.h, since errno is used.

### DIFF
--- a/src/mount/fuse/daemonize.cc
+++ b/src/mount/fuse/daemonize.cc
@@ -24,6 +24,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <errno.h>
 
 static int gWaiter[2] = {-1, -1};
 


### PR DESCRIPTION
This was needed to compile on OS X.